### PR TITLE
Correct git url

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ sudo apt-get install build-essentials git
 ```
 - Clone this repository somewhere in your hard drive
 ```bash
-git clone https://github.com/mnishihan/dev-tld-resolver.git
+git clone https://github.com/puma/dev-tld-resolver.git
 ```
 -  Run following command to build & install the tool
 ```


### PR DESCRIPTION
The README still displays the URL from the original repo. This is confusing because if you clone that repo, [the install instructions in its README](https://github.com/mnishihan/dev-tld-resolver#ubuntu) are different.