### PR TITLE
Change default domain from .dev to .puma since Google took .dev into the forbidden lands of HSTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple top level domain (NSSwitch hosts) resolver for linux based development en
 
 # Supported Linux Distributions
 
-This tool is developed in a Ubuntu 12.04 system & tested in later vesrions of Ubuntu & Ubuntu derivatives. Even though not tested, it should also work in other Linux distributions that supports/uses [nsswitch.conf](http://man7.org/linux/man-pages/man5/nsswitch.conf.5.html) file based configuration. In general, if your Linux installation has a file named **nsswitch.conf** in **/etc/** folder, then you should be ready to go with using this tool.
+This tool is developed in a Ubuntu 12.04 system & tested in later versions of Ubuntu & Ubuntu derivatives. Even though not tested, it should also work in other Linux distributions that supports/uses [nsswitch.conf](http://man7.org/linux/man-pages/man5/nsswitch.conf.5.html) file based configuration. In general, if your Linux installation has a file named **nsswitch.conf** in **/etc/** folder, then you should be ready to go with using this tool.
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ sudo make install
 
 > It's very important that you run the ```make install``` command as **root** or using **sudo**, otherwise installation will fail.
 
-- As root (or in super user mode with sudo) also edit **/etc/environment** using a text editor of your choice and export a global environment variable named **DEV_TLD_DOMAINS** with comma separated list of Top Level Domains (**tld**) that you want to resolve to ```127.0.0.1``` automatically. For example, if you want ```.dev```, ```.wp```, ```.dpl``` top level domains to be resolved by **dev-tld-resolver**, your **/etc/environment** should have following line within it somewhere.
+- As root (or in super user mode with sudo) also edit **/etc/environment** using a text editor of your choice and export a global environment variable named **DEV_TLD_DOMAINS** with comma separated list of Top Level Domains (**tld**) that you want to resolve to ```127.0.0.1``` automatically. For example, if you want ```.puma```, ~~```.dev```~~, ```.wp```, ```.dpl``` top level domains to be resolved by **dev-tld-resolver**, your **/etc/environment** should have following line within it somewhere.
 ```
-DEV_TLD_DOMAINS=dev,wp,dpl
+DEV_TLD_DOMAINS=puma,wp,dpl
 ```
 
-> Above step is optional if you don't need **dev-tld-resolver** to resolve top level domains other than ```.dev```, which is the default
+> Above step is optional if you don't need **dev-tld-resolver** to resolve top level domains other than ```.puma```, which is the default
 
-- Lastly as root (or in super user mode with sudo) edit ```/etc/nsswitch.conf``` file and append ```dev_tld``` to the line starting with ```hosts:```. 
+- Lastly as root (or in super user mode with sudo) edit ```/etc/nsswitch.conf``` file and append ```dev_tld``` to the line starting with ```hosts:```.
 
 > If you have following line starting with ```hosts:``` in ```/etc/nsswitch.conf``` file
 > ```
@@ -50,7 +50,7 @@ DEV_TLD_DOMAINS=dev,wp,dpl
 
 - Now logout or reboot your system and login again. After logging in into the system, open a command line and type following command
 ```
-ping test.dev
+ping test.puma
 ```
 If ping is successful, then **dev-tld-resolver** is installed & configured correctly.
 

--- a/src/nss_dev_tld.c
+++ b/src/nss_dev_tld.c
@@ -98,7 +98,7 @@ _nss_dev_tld_gethostbyname2_r(const char *name,
     char *env = getenv("DEV_TLD_DOMAINS");
     char *domains;
     if (env == NULL) {
-        domains = strdup("dev");
+        domains = strdup("puma");
     } else {
         domains = strdup(env);
     }


### PR DESCRIPTION
Google owns .dev and since Dec 2017 has activated HSTS, making it hard or impossible to use for local development combined with Chrome or other browsers that support HSTS.