### PR TITLE
Copy shared object on install instead of symlink

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -13,8 +13,7 @@ clean:
 	rm -f *.o *~ libnss_dev_tld.so.2
 
 install: libnss_dev_tld.so.2
-	ln -sf $(CURDIR)/libnss_dev_tld.so.2 /lib
+	cp --remove-destination $(CURDIR)/libnss_dev_tld.so.2 /lib
 
 uninstall:
 	rm /lib/libnss_dev_tld.so.2
-


### PR DESCRIPTION
This one-line change makes the `make install` step copy the generated shared object file into `/lib` instead of symlinking it. This improves the Linux installation process by allowing the user to remove the original git directory after installation if they desire.

I manually tested this on Ubuntu 20.04 as part of a larger install and it worked fine.